### PR TITLE
don't look for an 'n' branch called 'br.nbr' if 'br' is at top level in the CAF

### DIFF
--- a/BasicTypesProxy.cxx
+++ b/BasicTypesProxy.cxx
@@ -443,8 +443,13 @@ namespace caf
   std::string VectorProxyBase::NName() const
   {
     const int idx = fName.find_last_of('.');
-    // foo.bar.baz -> foo.bar.nbaz
-    return fName.substr(0, idx)+".n"+fName.substr(idx+1);
+    if (idx != std::string::npos)
+      // foo.bar.baz -> foo.bar.nbaz
+      return fName.substr(0, idx)+".n"+fName.substr(idx+1);
+    else
+      // maybe the CAF is structured so this branch is at top level.
+      // then it should just be "n" + the branch name
+      return "n" + fName;
   }
 
   //----------------------------------------------------------------------


### PR DESCRIPTION
Most CAFs' top-level branch is called "rec" or something similar.  But in the case where they aren't, and the `StandardRecord` is serialized so that all its branches wind up at top level instead, `NName()` currently looks for a 'count' branch for `vector` branch `br` as `br.nbr` instead of just `nbr`.  Fix that.