### PR TITLE
fBase being fixed from first "entry" since v00.36

### DIFF
--- a/BasicTypesProxy.cxx
+++ b/BasicTypesProxy.cxx
@@ -85,35 +85,19 @@ namespace caf
   }
 
   //----------------------------------------------------------------------
-  const long kZero = 0;
-
-  // Sigh. For multi-tree flatcafs, 'base' is being updated by the caller to
-  // give the row in the tree. But for single-tree flatcafs, this field
-  // signifies a starting position within the array for the current row, and
-  // should always be zero (ignoring the caller) for top-level fields. Enforce
-  // that here.
-  const long& AdjustBase(const long& base, CAFType type, const std::string& name)
-  {
-    if(type == kFlat && NSubscripts(name) == 0) return kZero;
-    return base;
-  }
-
-  //----------------------------------------------------------------------
   template<class T> Proxy<T>::Proxy(TTree* tr, const std::string& name, const long& base, int offset)
     : fName(name), fType(GetCAFType(tr)),
       fLeaf(0), fTree(tr),
-      fBase(AdjustBase(base, fType, fName)), fOffset(offset),
+      fBase(base), fOffset(offset),
       fLeafInfo(0), fBranch(0), fTTF(0), fEntry(-1), fSubIdx(0)
   {
   }
-
-  const long kDummyBase = -1;
 
   //----------------------------------------------------------------------
   template<class T> Proxy<T>::Proxy(const Proxy<T>& p)
     : fName("copy of "+p.fName), fType(kCopiedRecord),
       fLeaf(0), fTree(0),
-      fBase(kDummyBase), fOffset(-1),
+      fBase(-1), fOffset(-1),
       fLeafInfo(0), fBranch(0), fTTF(0), fEntry(-1), fSubIdx(-1)
   {
     // Ensure that the value is evaluated and baked in in the parent object, so
@@ -125,7 +109,7 @@ namespace caf
   template<class T> Proxy<T>::Proxy(const Proxy&& p)
     : fName("move of "+p.fName), fType(kCopiedRecord),
       fLeaf(0), fTree(0),
-      fBase(kDummyBase), fOffset(-1),
+      fBase(-1), fOffset(-1),
       fLeafInfo(0), fBranch(0), fTTF(0), fEntry(-1), fSubIdx(-1)
   {
     // Ensure that the value is evaluated and baked in in the parent object, so

--- a/BasicTypesProxy.h
+++ b/BasicTypesProxy.h
@@ -54,7 +54,7 @@ namespace caf
 
     friend class Restorer;
 
-    Proxy(TTree* tr, const std::string& name, long base, int offset);
+    Proxy(TTree* tr, const std::string& name, const long& base, int offset);
     Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, 0, 0) {}
 
     // Need to be copyable because Vars return us directly
@@ -104,7 +104,7 @@ namespace caf
     TTree* fTree;
 
     // Flat
-    long fBase;
+    const long& fBase;
     int fOffset;
 
     // Nested
@@ -125,7 +125,7 @@ namespace caf
     ArrayVectorProxyBase(TTree* tr,
                          const std::string& name,
                          bool isNestedContainer,
-                         long base, int offset);
+                         const long& base, int offset);
 
     virtual ~ArrayVectorProxyBase();
 
@@ -147,9 +147,10 @@ namespace caf
     std::string fName;
     bool fIsNestedContainer;
     CAFType fType;
-    long fBase;
+    const long& fBase;
     int fOffset;
     mutable Proxy<long long>* fIdxP;
+    mutable long fIdx;
   };
 
   // Helper functions that don't need to be templated
@@ -163,7 +164,7 @@ namespace caf
     void resize(size_t i);
 
   protected:
-    VectorProxyBase(TTree* tr, const std::string& name, bool isNestedContainer, long base, int offset);
+    VectorProxyBase(TTree* tr, const std::string& name, bool isNestedContainer, const long& base, int offset);
 
     std::string LengthField() const;
     /// Helper for LengthField()
@@ -176,12 +177,12 @@ namespace caf
   template<class T> class Proxy<std::vector<T>>: public VectorProxyBase
   {
   public:
-    Proxy(TTree* tr, const std::string& name, long base, int offset)
+    Proxy(TTree* tr, const std::string& name, const long& base, int offset)
       : VectorProxyBase(tr, name, is_vec<T>::value || std::is_array_v<T>, base, offset)
     {
     }
 
-    Proxy(TTree* tr, const std::string& name) : Proxy(0, tr, name, 0, 0) {}
+    Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, 0, 0) {}
 
     ~Proxy(){for(Proxy<T>* e: fElems) delete e;}
 
@@ -239,8 +240,9 @@ namespace caf
       if(i >= fElems.size()) fElems.resize(i+1);
 
       EnsureIdxP();
+      if(fIdxP) fIdx = *fIdxP; // store into an actual value we can point to
 
-      if(!fElems[i]) fElems[i] = new Proxy<T>(fTree, Subscript(i), fIdxP ? fIdxP->GetValue() : 0l, i);
+      if(!fElems[i]) fElems[i] = new Proxy<T>(fTree, Subscript(i), fIdx, i);
     }
 
     mutable std::vector<Proxy<T>*> fElems;
@@ -265,7 +267,7 @@ namespace caf
   template<class T, unsigned int N> class Proxy<T[N]> : public ArrayVectorProxyBase
   {
   public:
-    Proxy(TTree* tr, const std::string& name, long base, int offset)
+    Proxy(TTree* tr, const std::string& name, const long& base, int offset)
       : ArrayVectorProxyBase(tr, name, is_vec<T>::value || std::is_array_v<T>, base, offset)
     {
       fElems.fill(0); // ensure initialized to null
@@ -284,11 +286,13 @@ namespace caf
     const Proxy<T>& operator[](size_t i) const
     {
       EnsureElem(i);
+      if(fIdxP) fIdx = *fIdxP;
       return *fElems[i];
     }
     Proxy<T>& operator[](size_t i)
     {
       EnsureElem(i);
+      if(fIdxP) fIdx = *fIdxP;
       return *fElems[i];
     }
 
@@ -312,7 +316,7 @@ namespace caf
       if(fType != kFlat || TreeHasLeaf(fTree, IndexField())){
         // Regular out-of-line array, handled the same as a vector.
         EnsureIdxP();
-        fElems[i] = new Proxy<T>(fTree, Subscript(i), fIdxP ? fIdxP->GetValue() : 0, i);
+        fElems[i] = new Proxy<T>(fTree, Subscript(i), fIdx, i);
       }
       else{
         // No ..idx field implies this is an "inline" array where the elements

--- a/gen_srproxy
+++ b/gen_srproxy
@@ -137,7 +137,7 @@ proxy_hdr_body = '''
 template<> class {PTYPE}{BASE}
 {{
 public:
-  Proxy(TTree* tr, const std::string& name, long base, int offset);
+  Proxy(TTree* tr, const std::string& name, const long& base, int offset);
   Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, 0, 0) {{}}
   Proxy(const Proxy&) = delete;
   Proxy(const Proxy&&) = delete;
@@ -197,7 +197,7 @@ def cxx_prolog():
 
 # -----------------------------------------------------------------------------
 proxy_cxx_body = '''
-{PTYPE}::Proxy(TTree* tr, const std::string& name, long base, int offset) :
+{PTYPE}::Proxy(TTree* tr, const std::string& name, const long& base, int offset) :
 {INITS}
 {{
 }}


### PR DESCRIPTION
Since v00.36, when analyzing cafs using `sbnana`, we observed wrong indexing for the  vector objects. This PR brings back the call-by-reference feature for base variables.  Detailed description is documented in the docdb : https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=29431