### PR TITLE
revive use of kDummyBase (originally implemented in ba6e832).

### DIFF
--- a/BasicTypesProxy.cxx
+++ b/BasicTypesProxy.cxx
@@ -188,11 +188,13 @@ namespace caf
   {
   }
 
+  const long kDummyBase = -1;
+  
   //----------------------------------------------------------------------
   template<class T> Proxy<T>::Proxy(const Proxy<T>& p)
     : fName("copy of "+p.fName), fType(kCopiedRecord),
       fLeaf(0), fTree(0),
-      fBase(-1), fOffset(-1),
+      fBase(kDummyBase), fOffset(-1),
       fLeafInfo(0), fBranch(0), fTTF(0), fEntry(-1), fSubIdx(-1)
   {
     // Ensure that the value is evaluated and baked in in the parent object, so
@@ -204,7 +206,7 @@ namespace caf
   template<class T> Proxy<T>::Proxy(const Proxy&& p)
     : fName("move of "+p.fName), fType(kCopiedRecord),
       fLeaf(0), fTree(0),
-      fBase(-1), fOffset(-1),
+      fBase(kDummyBase), fOffset(-1),
       fLeafInfo(0), fBranch(0), fTTF(0), fEntry(-1), fSubIdx(-1)
   {
     // Ensure that the value is evaluated and baked in in the parent object, so


### PR DESCRIPTION
Makes the compiler happy by stopping lots of obnoxious warnings from `-Wextra` about a temporary bound to `fBase` that only persists until the constructor exits. Need to be careful with those since here we're binding const& to a temporary.