### PR TITLE
Eliminate reference-to-temporary issue everywhere

### DIFF
--- a/BasicTypesProxy.cxx
+++ b/BasicTypesProxy.cxx
@@ -188,11 +188,13 @@ namespace caf
   {
   }
 
+  const int kDummyBaseUninit = -1;
+
   //----------------------------------------------------------------------
   template<class T> Proxy<T>::Proxy(const Proxy<T>& p)
     : fName("copy of "+p.fName), fType(kCopiedRecord),
       fLeaf(0), fTree(0),
-      fBase(kDummyBase), fOffset(-1),
+      fBase(kDummyBaseUninit), fOffset(-1),
       fLeafInfo(0), fBranch(0), fTTF(0), fEntry(-1), fSubIdx(-1)
   {
     // Ensure that the value is evaluated and baked in in the parent object, so
@@ -204,7 +206,7 @@ namespace caf
   template<class T> Proxy<T>::Proxy(const Proxy&& p)
     : fName("move of "+p.fName), fType(kCopiedRecord),
       fLeaf(0), fTree(0),
-      fBase(kDummyBase), fOffset(-1),
+      fBase(kDummyBaseUninit), fOffset(-1),
       fLeafInfo(0), fBranch(0), fTTF(0), fEntry(-1), fSubIdx(-1)
   {
     // Ensure that the value is evaluated and baked in in the parent object, so

--- a/BasicTypesProxy.cxx
+++ b/BasicTypesProxy.cxx
@@ -188,8 +188,6 @@ namespace caf
   {
   }
 
-  const long kDummyBase = -1;
-  
   //----------------------------------------------------------------------
   template<class T> Proxy<T>::Proxy(const Proxy<T>& p)
     : fName("copy of "+p.fName), fType(kCopiedRecord),

--- a/BasicTypesProxy.h
+++ b/BasicTypesProxy.h
@@ -58,7 +58,7 @@ namespace caf
     friend class Restorer;
 
     Proxy(TTree* tr, const std::string& name, const long& base, int offset);
-    Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, 0, 0) {}
+    Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, kDummyBase, 0) {}
 
     // Need to be copyable because Vars return us directly
     Proxy(const Proxy&);
@@ -186,7 +186,7 @@ namespace caf
     {
     }
 
-    Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, 0, 0) {}
+    Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, kDummyBase, 0) {}
 
     ~Proxy(){for(Proxy<T>* e: fElems) delete e;}
 
@@ -277,7 +277,7 @@ namespace caf
       fElems.fill(0); // ensure initialized to null
     }
 
-    Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, 0, 0) {}
+    Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, kDummyBase, 0) {}
 
     ~Proxy()
     {

--- a/BasicTypesProxy.h
+++ b/BasicTypesProxy.h
@@ -16,7 +16,7 @@ class TTree;
 namespace caf
 {
   /// this constant is passed by reference into the various Proxy constructors.
-  inline const long kDummyBase = -1;
+  inline const long kDummyBase = 0;
 
   class SRBranchRegistry
   {

--- a/BasicTypesProxy.h
+++ b/BasicTypesProxy.h
@@ -15,6 +15,9 @@ class TTree;
 
 namespace caf
 {
+  /// this constant is passed by reference into the various Proxy constructors.
+  inline const long kDummyBase = -1;
+
   class SRBranchRegistry
   {
   public:

--- a/gen_srproxy
+++ b/gen_srproxy
@@ -138,7 +138,7 @@ template<> class {PTYPE}{BASE}
 {{
 public:
   Proxy(TTree* tr, const std::string& name, const long& base, int offset);
-  Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, 0, 0) {{}}
+  Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, kDummyBase, 0) {{}}
   Proxy(const Proxy&) = delete;
   Proxy(const Proxy&&) = delete;
   Proxy& operator=(const {TYPE}& x);


### PR DESCRIPTION
1543a64 fixed some instances where we were binding a temporary to a reference, but a number of them remained.  This PR purports to fix the rest of them.

I was forced to create a second global var to be bound to, since the value that was being passed around in all these other cases was 0, instead of -1, but this doesn't seem to be a big deal.  I don't foresee any side effects other than Flat CAF reading working again :smile: