### PR TITLE
don't generate Proxy entries for static class members

### DIFF
--- a/gen_srproxy
+++ b/gen_srproxy
@@ -54,7 +54,7 @@ def full_name(type):
 
 def members(klass):
     # Only accept direct members. Sort to keep .cxx and .h consistent
-    return sorted([v for v in klass.variables(allow_empty = True) if v.parent == klass])
+    return sorted([v for v in klass.variables(allow_empty = True) if v.parent == klass and not v.type_qualifiers.has_static])
 
 
 def base_class(klass):


### PR DESCRIPTION
Static class members are shared amongst all instances of a class, so they shouldn't be Proxy'd.  (They're not part of the event-by-event record.)  This PR prevents that from accidentally happening.