### PR TITLE
fix for initialization errors found with clang.

### DIFF
--- a/BasicTypesProxy.cxx
+++ b/BasicTypesProxy.cxx
@@ -188,7 +188,7 @@ namespace caf
   {
   }
 
-  const int kDummyBaseUninit = -1;
+  const long kDummyBaseUninit = -1;
 
   //----------------------------------------------------------------------
   template<class T> Proxy<T>::Proxy(const Proxy<T>& p)


### PR DESCRIPTION
Clang  was making a temporary long from the int.
Make it a const long from the get-go.
Initialization errors observed for srproxy v00.41 by DUNE (Jake Calcutt) and EMPHATIC (GD). Proposed solution being implemented here supplied by investigations by Tom Junk. Thank you! Once merged, I will cut a new release of srproxy.