### PR TITLE
update castxml for py3 builds to v0_5_1.

### DIFF
--- a/make_ups_product.sh
+++ b/make_ups_product.sh
@@ -59,7 +59,7 @@ ACTION=SETUP
   EnvSet(${prodname_upper}_INC, \${UPS_PROD_DIR}/include )
   pathPrepend(PATH, \${UPS_PROD_DIR}/bin )
 
-  setupRequired(castxml v0_4_2)
+  setupRequired(castxml v0_5_1)
   setupRequired(pygccxml v2_1_0c -q p392)
 
 FLAVOR=ANY
@@ -72,7 +72,7 @@ ACTION=SETUP
   EnvSet(${prodname_upper}_INC, \${UPS_PROD_DIR}/include )
   pathPrepend(PATH, \${UPS_PROD_DIR}/bin )
 
-  setupRequired(castxml v0_4_2)
+  setupRequired(castxml v0_5_1)
   setupRequired(pygccxml v2_2_1b -q p3913)
 EOF
 


### PR DESCRIPTION
A request via @cafana/dune to aid the building of `duneanaobj`; able to build without any ugly hacks but with `castxml v0_5_1`
More info on [Redmine Issue 28197](https://cdcvs.fnal.gov/redmine/issues/28197)