### PR TITLE
Enable 'ancestry' traversal for Proxied objects

### DIFF
--- a/BasicTypesProxy.h
+++ b/BasicTypesProxy.h
@@ -56,6 +56,7 @@ namespace caf
     public:
       /// note: this is NOT a copy constructor!  Specifies the object that's this one's parent.
       explicit Lineage(const Lineage * parent) : fParent(parent) {}
+      virtual ~Lineage() = default;
 
       /// \brief Search through the stored lineage to find ancestor of given type.  If multiple, returns only the closest one.
       /// \tparam T   Object type to look for (e.g.: SRProxy)

--- a/BasicTypesProxy.h
+++ b/BasicTypesProxy.h
@@ -50,15 +50,44 @@ namespace caf
 
   class Restorer;
 
-  template<class T> class Proxy
+  /// Base class for all proxy types, intended to help trace ancestry
+  class Lineage
+  {
+    public:
+      /// note: this is NOT a copy constructor!  Specifies the object that's this one's parent.
+      explicit Lineage(const Lineage * parent) : fParent(parent) {}
+
+      /// \brief Search through the stored lineage to find ancestor of given type.  If multiple, returns only the closest one.
+      /// \tparam T   Object type to look for (e.g.: SRProxy)
+      /// \return  Pointer to closest ancestor (fewest links separating them) of type T, or nullptr if none found
+      template <typename T>
+      const T * Ancestor()
+      {
+        const Lineage * candAnc = this;
+        while ( (candAnc = candAnc->Parent()) )
+        {
+          if (auto ret = dynamic_cast<const T*>(candAnc))
+            return ret;
+        }
+        return nullptr;
+      }
+
+      const Lineage * Parent() const { return fParent; }
+
+    private:
+      const Lineage * fParent = nullptr;
+  };
+
+  template<class T> class Proxy : public Lineage
   {
   public:
     static_assert(std::is_arithmetic_v<T> || std::is_enum_v<T> || std::is_same_v<T, std::string>, "Invalid type for basic type Proxy");
 
     friend class Restorer;
 
-    Proxy(TTree* tr, const std::string& name, const long& base, int offset);
-    Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, kDummyBase, 0) {}
+    Proxy(TTree *tr, const std::string &name, const long &base, int offset, const Lineage * parent = nullptr);
+    Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, kDummyBase, 0, nullptr)
+    {}
 
     // Need to be copyable because Vars return us directly
     Proxy(const Proxy&);
@@ -120,7 +149,7 @@ namespace caf
   };
 
   // Helper functions that don't need to be templated
-  class ArrayVectorProxyBase
+  class ArrayVectorProxyBase : public Lineage
   {
   public:
     std::string Name() const {return fName;}
@@ -129,7 +158,8 @@ namespace caf
     ArrayVectorProxyBase(TTree* tr,
                          const std::string& name,
                          bool isNestedContainer,
-                         const long& base, int offset);
+                         const long& base, int offset,
+                         const Lineage * parent = nullptr);
 
     virtual ~ArrayVectorProxyBase();
 
@@ -168,7 +198,8 @@ namespace caf
     void resize(size_t i);
 
   protected:
-    VectorProxyBase(TTree* tr, const std::string& name, bool isNestedContainer, const long& base, int offset);
+    VectorProxyBase(TTree* tr, const std::string& name, bool isNestedContainer, const long& base, int offset,
+                    const Lineage * parent = nullptr);
 
     std::string LengthField() const;
     /// Helper for LengthField()
@@ -181,12 +212,13 @@ namespace caf
   template<class T> class Proxy<std::vector<T>>: public VectorProxyBase
   {
   public:
-    Proxy(TTree* tr, const std::string& name, const long& base, int offset)
-      : VectorProxyBase(tr, name, is_vec<T>::value || std::is_array_v<T>, base, offset)
+    Proxy(TTree *tr, const std::string &name, const long &base, int offset, const Lineage *parent)
+      : VectorProxyBase(tr, name, is_vec<T>::value || std::is_array_v<T>, base, offset, parent)
     {
     }
 
-    Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, kDummyBase, 0) {}
+    Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, kDummyBase, 0, nullptr)
+    {}
 
     ~Proxy(){for(Proxy<T>* e: fElems) delete e;}
 
@@ -246,7 +278,7 @@ namespace caf
       EnsureIdxP();
       if(fIdxP) fIdx = *fIdxP; // store into an actual value we can point to
 
-      if(!fElems[i]) fElems[i] = new Proxy<T>(fTree, Subscript(i), fIdx, i);
+      if(!fElems[i]) fElems[i] = new Proxy<T>(fTree, Subscript(i), fIdx, i, nullptr);
     }
 
     mutable std::vector<Proxy<T>*> fElems;
@@ -271,13 +303,14 @@ namespace caf
   template<class T, unsigned int N> class Proxy<T[N]> : public ArrayVectorProxyBase
   {
   public:
-    Proxy(TTree* tr, const std::string& name, const long& base, int offset)
+    Proxy(TTree *tr, const std::string &name, const long &base, int offset, const Lineage *parent)
       : ArrayVectorProxyBase(tr, name, is_vec<T>::value || std::is_array_v<T>, base, offset)
     {
       fElems.fill(0); // ensure initialized to null
     }
 
-    Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, kDummyBase, 0) {}
+    Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, kDummyBase, 0, nullptr)
+    {}
 
     ~Proxy()
     {
@@ -320,13 +353,13 @@ namespace caf
       if(fType != kFlat || TreeHasLeaf(fTree, IndexField())){
         // Regular out-of-line array, handled the same as a vector.
         EnsureIdxP();
-        fElems[i] = new Proxy<T>(fTree, Subscript(i), fIdx, i);
+        fElems[i] = new Proxy<T>(fTree, Subscript(i), fIdx, i, nullptr);
       }
       else{
         // No ..idx field implies this is an "inline" array where the elements
         // are in individual branches like foo.0.bar
         const std::string dotname = fName+"."+std::to_string(i);
-        fElems[i] = new Proxy<T>(fTree, dotname, fBase, fOffset);
+        fElems[i] = new Proxy<T>(fTree, dotname, fBase, fOffset, nullptr);
       }
     }
 

--- a/BasicTypesProxy.h
+++ b/BasicTypesProxy.h
@@ -279,7 +279,8 @@ namespace caf
       EnsureIdxP();
       if(fIdxP) fIdx = *fIdxP; // store into an actual value we can point to
 
-      if(!fElems[i]) fElems[i] = new Proxy<T>(fTree, Subscript(i), fIdx, i, nullptr);
+      // note that the contained elements should point to the vector's parent, not the vector
+      if(!fElems[i]) fElems[i] = new Proxy<T>(fTree, Subscript(i), fIdx, i, this->Parent());
     }
 
     mutable std::vector<Proxy<T>*> fElems;

--- a/BasicTypesProxy.h
+++ b/BasicTypesProxy.h
@@ -62,7 +62,7 @@ namespace caf
       /// \tparam T   Object type to look for (e.g.: SRProxy)
       /// \return  Pointer to closest ancestor (fewest links separating them) of type T, or nullptr if none found
       template <typename T>
-      const T * Ancestor()
+      const T * Ancestor() const
       {
         const Lineage * candAnc = this;
         while ( (candAnc = candAnc->Parent()) )

--- a/gen_srproxy
+++ b/gen_srproxy
@@ -137,7 +137,7 @@ proxy_hdr_body = '''
 template<> class {PTYPE}{BASE}
 {{
 public:
-  Proxy(TTree* tr, const std::string& name, const long& base, int offset);
+  Proxy(TTree* tr, const std::string& name, const long& base, int offset, const Lineage * parent = nullptr);
   Proxy(TTree* tr, const std::string& name) : Proxy(tr, name, kDummyBase, 0) {{}}
   Proxy(const Proxy&) = delete;
   Proxy(const Proxy&&) = delete;
@@ -197,7 +197,7 @@ def cxx_prolog():
 
 # -----------------------------------------------------------------------------
 proxy_cxx_body = '''
-{PTYPE}::Proxy(TTree* tr, const std::string& name, const long& base, int offset) :
+{PTYPE}::Proxy(TTree* tr, const std::string& name, const long& base, int offset, const Lineage * parent) :
 {INITS}
 {{
 }}
@@ -285,15 +285,17 @@ def emit(klass):
     base = base_class(klass)
     if base:
         pbtype = proxy_type(base)
-        proxy_inits += ['  {PBTYPE}(tr, name, base, offset)'.format(PBTYPE = pbtype)]
+        proxy_inits += ['  {PBTYPE}(tr, name, base, offset, parent)'.format(PBTYPE = pbtype)]
         flat_inits += ['  {PBTYPE}(tr, prefix, totsize, policy)'.format(PBTYPE = pbtype)]
         assign_body += ['  {PBTYPE}::operator=(sr);'.format(PBTYPE = pbtype)]
         checkequals_body += ['  {PBTYPE}::CheckEquals(sr);'.format(PBTYPE = pbtype)]
         fill_body += ['  {PBTYPE}::Fill(sr);'.format(PBTYPE = pbtype)]
         clear_body += ['  {PBTYPE}::Clear();'.format(PBTYPE = pbtype)]
+    else:
+        proxy_inits += ['  Lineage(parent)',]
 
     for v in members(klass):
-        proxy_inits += [ '  {NAME}(tr, Join(name, "{NAME}"), base, offset)'.format(NAME = v.name)]
+        proxy_inits += [ '  {NAME}(tr, Join(name, "{NAME}"), base, offset, this)'.format(NAME = v.name)]
         flat_inits += [ '  {NAME}(tr, prefix+".{NAME}", totsize, policy)'.format(NAME = v.name)]
 
         memlist += ['  {PTYPE} {NAME};'.format(PTYPE = proxy_type(v.decl_type), NAME = v.name)]
@@ -322,9 +324,13 @@ def emit(klass):
                                  PTYPE = proxy_type(klass),
                                  SHORTTYPE = friendly_name(klass)))
 
+    if base:
+        base = proxy_type(base)
+    elif not gFlat:
+        base = "caf::Lineage"
     fhdr.write(hdr_body().format(TYPE = full_name(klass),
                                  PTYPE = proxy_type(klass),
-                                 BASE = ' : public '+proxy_type(base) if base else '',
+                                 BASE = (' : public ' + base) if base else '',
                                  ADDONS = class_to_addons[klass.name] if klass.name in class_to_addons else '',
                                  MEMBERS = '\n'.join(memlist)))
 

--- a/make_ups_product.sh
+++ b/make_ups_product.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-if [ $# != 1 ]
+if [ $# = 0 ] || [ $# -gt 2 ]
 then
-    echo Usage: make_ups_product.sh VERSION
+    echo Usage: make_ups_product.sh VERSION [UPS_DIR]
     exit 2
 fi
 
 version=$1
+[ -z "$2" ] && ups_dir="$PWD" || ups_dir="$2"
 
 prodname_lower=srproxy
 prodname_mixed=SRProxy
@@ -15,7 +16,7 @@ prodname_upper=SRPROXY
 INCS="BasicTypesProxy.h BasicTypesProxy.cxx FlatBasicTypes.h IBranchPolicy.h"
 BINS='gen_srproxy'
 
-dest=$prodname_lower/$version
+dest=$ups_dir/$prodname_lower/$version
 
 mkdir -p $dest || exit 1
 

--- a/make_ups_product.sh
+++ b/make_ups_product.sh
@@ -60,7 +60,7 @@ ACTION=SETUP
   EnvSet(${prodname_upper}_INC, \${UPS_PROD_DIR}/include )
   pathPrepend(PATH, \${UPS_PROD_DIR}/bin )
 
-  setupRequired(castxml v0_4_2)
+  setupRequired(castxml v0_5_1)
   setupRequired(pygccxml v2_1_0c -q p392)
 
 FLAVOR=ANY
@@ -73,7 +73,7 @@ ACTION=SETUP
   EnvSet(${prodname_upper}_INC, \${UPS_PROD_DIR}/include )
   pathPrepend(PATH, \${UPS_PROD_DIR}/bin )
 
-  setupRequired(castxml v0_4_2)
+  setupRequired(castxml v0_5_1)
   setupRequired(pygccxml v2_2_1b -q p3913)
 
 FLAVOR=ANY

--- a/make_ups_product.sh
+++ b/make_ups_product.sh
@@ -75,12 +75,26 @@ ACTION=SETUP
 
   setupRequired(castxml v0_4_2)
   setupRequired(pygccxml v2_2_1b -q p3913)
+
+FLAVOR=ANY
+QUALIFIERS=py3915
+
+ACTION=SETUP
+  setupEnv()
+  proddir()
+  EnvSet(${prodname_upper}_VERSION, \${UPS_PROD_VERSION} )
+  EnvSet(${prodname_upper}_INC, \${UPS_PROD_DIR}/include )
+  pathPrepend(PATH, \${UPS_PROD_DIR}/bin )
+
+  setupRequired(castxml v0_5_1)
+  setupRequired(pygccxml v2_2_1b -q p3915)
+
 EOF
 
 echo ${dest}.version
 mkdir ${dest}.version || exit 1
 
-for qual in py2 py3 py3913
+for qual in py2 py3 py3913 py3915
 do
 cat > ${dest}.version/NULL_$qual <<EOF
 FILE = version


### PR DESCRIPTION
There are certain situations where being able to navigate the ancestry tree of `StandardRecord` objects is helpful.  Most commonly this is when one wants to find, e.g., a "sibling" object to the one under study---for example, reconstructed showers within the same reconstructed event as a given track.

Traditionally users would have the whole `StandardRecord` object at their disposal, which makes this type of tree traversal straightforward.  However, the "source-sink" paradigm [introduced in CAFAnaCore v2](https://github.com/cafana/CAFAnaCore/commit/7085ba24f72a4369f1503535ff8a02f8f5061865) changes the workflow substantially for CAFAna users.  There, a user typically has only the output of a pipeline of "source-sink" objects chained together, which means they receive only the final `SR` object.  If they want to move up or laterally in the hierarchy, there's no way to do it.

This PR introduces a mechanism by which each object that a `Proxy` is created for now knows its ancestor object.  So one can ask, e.g., given a `caf::SRRecoParticleProxy*` called `part`,
```c++
const caf::SRProxy * top = part->Ancestor<caf::SRProxy>();
```
to get to the top-level `SRProxy` object, from which one can do whatever is needed.

This should be a small overhead change in terms of memory footprint and storage; it creates a base class for all `SR` objects containing a single pointer to the parent object, which is filled by the constructors.  It will slightly slow the usage down because the `SR` classes are all now `virtual`, but I didn't notice anything appreciable in testing.  Experiments that choose to just ignore it shouldn't notice the difference.  However it adds another thing the updated proxy generation (PR #3) will need to do 😬 